### PR TITLE
Show errors as part of the web page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ testem.log
 .DS_Store
 
 ### VisualStudioCode ###
+.vscode
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "${workspaceFolder}\\venv\\Scripts\\python.exe"
-}

--- a/portfolio/portfolioManager/templates/base.html
+++ b/portfolio/portfolioManager/templates/base.html
@@ -33,6 +33,20 @@
                 {% endif %}
         </div>
     </div>
+
+    {% if error_message %}
+    <p>
+    <div class="row">
+        <div class="col-10 offset-1">
+            <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                <strong>{{ error_message }}</strong>
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+        </div>
+    </div>
+    </p>{% endif %}
         
 
         <div id="content">

--- a/portfolio/portfolioManager/templates/portfolioManager/login.html
+++ b/portfolio/portfolioManager/templates/portfolioManager/login.html
@@ -4,12 +4,7 @@
 
 {% block title %} Login {% endblock %} 
 
-{% block content %} 
-
-{% if error_message %}
-<p>
-    <strong>{{ error_message }}</strong>
-</p>{% endif %}
+{% block content %}
 
 <form action="{% url 'portfolioManager:login' %}" method="post">
     {% csrf_token %} 

--- a/portfolio/portfolioManager/views/login.py
+++ b/portfolio/portfolioManager/views/login.py
@@ -15,9 +15,9 @@ class LoginView(View):
             login(request, user)
             return redirect('/')
         else:
-            return HttpResponse('Unsuccessful Login')
+            return render(request, 'portfolioManager/login.html', {'error_message': 'Invalid Credentials'})
 
 class LogoutView(LoginRequiredMixin, View):
     def get(self, request):
         logout(request)
-        return redirect('/login/')
+        return redirect('/login')


### PR DESCRIPTION
* moved the **_error_message_** key to base.html for access across all pages.
* unsuccessful login attempts are met with a friendly error message now.